### PR TITLE
Missing policy templates

### DIFF
--- a/examples/vault/ti-policy.all.hcl.tpl
+++ b/examples/vault/ti-policy.all.hcl.tpl
@@ -1,0 +1,9 @@
+#  This policy template controls the path using:
+#  * cluster-region
+#  * cluster-name
+#  * namespace
+#  * images
+
+path "secret/data/ti-demo-all/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.cluster-region}}/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.cluster-name}}/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.namespace}}/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.images}}/*" {
+  capabilities = ["read"]
+}

--- a/examples/vault/ti-policy.n.hcl.tpl
+++ b/examples/vault/ti-policy.n.hcl.tpl
@@ -1,0 +1,9 @@
+#  This policy template controls the path using:
+#  * cluster-region
+#  * cluster-name
+#  * namespace
+
+# Policy controlling cluster-region,cluster-name and namespace
+path "secret/data/ti-demo-n/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.cluster-region}}/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.cluster-name}}/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.namespace}}/*" {
+  capabilities = ["read", "list"]
+}

--- a/examples/vault/ti-policy.r.hcl.tpl
+++ b/examples/vault/ti-policy.r.hcl.tpl
@@ -1,0 +1,6 @@
+#  This policy template controls the path using:
+#  * cluster-region
+
+path "secret/data/ti-demo-r/{{identity.entity.aliases.<%MOUNT_ACCESSOR%>.metadata.cluster-region}}/*" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
During the vault-plugin move to components, the policy templates were accidently removed. 