### PR TITLE
Added a helm check for existing CRD

### DIFF
--- a/charts/spire/ext/spiffeid.spiffe.io_spiffeids.yaml
+++ b/charts/spire/ext/spiffeid.spiffe.io_spiffeids.yaml
@@ -1,0 +1,110 @@
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: spiffeids.spiffeid.spiffe.io
+spec:
+  group: spiffeid.spiffe.io
+  names:
+    kind: SpiffeID
+    listKind: SpiffeIDList
+    plural: spiffeids
+    singular: spiffeid
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SpiffeID is the Schema for the spiffeid API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SpiffeIDSpec defines the desired state of SpiffeID
+          properties:
+            dnsNames:
+              items:
+                type: string
+              type: array
+            federatesWith:
+              items:
+                type: string
+              type: array
+            parentId:
+              type: string
+            selector:
+              properties:
+                arbitrary:
+                  description: Arbitrary selectors
+                  items:
+                    type: string
+                  type: array
+                containerImage:
+                  description: Container image to match for this spiffe ID
+                  type: string
+                containerName:
+                  description: Container name to match for this spiffe ID
+                  type: string
+                namespace:
+                  description: Namespace to match for this spiffe ID
+                  type: string
+                nodeName:
+                  description: Node name to match for this spiffe ID
+                  type: string
+                podLabel:
+                  additionalProperties:
+                    type: string
+                  description: Pod label name/value to match for this spiffe ID
+                  type: object
+                podName:
+                  description: Pod name to match for this spiffe ID
+                  type: string
+                podUid:
+                  description: Pod UID to match for this spiffe ID
+                  type: string
+                serviceAccount:
+                  description: ServiceAccount to match for this spiffe ID
+                  type: string
+              type: object
+            spiffeId:
+              type: string
+          required:
+          - parentId
+          - selector
+          - spiffeId
+          type: object
+        status:
+          description: SpiffeIDStatus defines the observed state of SpiffeID
+          properties:
+            entryId:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              type: string
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/spire/templates/NOTES.txt
+++ b/charts/spire/templates/NOTES.txt
@@ -40,3 +40,11 @@ To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
+
+{{- if not (lookup "apiextensions.k8s.io/v1beta1" "CustomResourceDefinition" "" "spiffeids.spiffeid.spiffe.io") -}}
+  {{ printf "\n" }}
+  Generate new SPIFFEID CRD
+{{- else -}}
+  {{ printf "\n" }}
+  SPIFFEID CRD already exists
+{{- end -}}

--- a/charts/spire/templates/spiffeid.spiffe.io_spiffeids.tpl
+++ b/charts/spire/templates/spiffeid.spiffe.io_spiffeids.tpl
@@ -1,4 +1,8 @@
----
+{{- if not (lookup "apiextensions.k8s.io/v1beta1" "CustomResourceDefinition" "" "spiffeids.spiffeid.spiffe.io") -}}
+{{/*
+    If does not exist, generate new SPIFFEID CRD
+*/}}
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -107,3 +111,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
+{{- end -}}

--- a/docs/spire-hints.md
+++ b/docs/spire-hints.md
@@ -115,7 +115,7 @@ Either re-run the agents installation again,
 or create the CRD manually:
 
 ```console
-kubectl -n spire create -f charts/spire/templates/spiffeid.spiffe.io_spiffeids.yaml
+kubectl -n spire create -f charts/spire/ext/spiffeid.spiffe.io_spiffeids.yaml
 ```
 ---
 **Problem:**
@@ -126,7 +126,7 @@ time="2021-10-01T16:50:45Z" level=error msg="Failed to watch the Workload API: r
 ```
 **Description:**
 
-The Workload Registar cannot connect to the SPIRE agent.
+The Workload Registrar cannot connect to the SPIRE agent.
 
 **Solution:**
 


### PR DESCRIPTION
Helm char uses helm's `lookup` function to check if the CRD SPIFFEID resource already exists prior to creating it. 

This PR addresses #128 
Signed-off-by: Mariusz Sabath <mrsabath@gmail.com>